### PR TITLE
Organize spotify api methods

### DIFF
--- a/src/components/AppPlayList/AppPlayList.js
+++ b/src/components/AppPlayList/AppPlayList.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import useTrack from '../../hooks/useTrack';
+import usePlaylist from '../../hooks/usePlaylist';
 import { SearchResults } from '../SearchResults/SearchResults.js';
 import PlayList from '../PlayList/PlayList.js';
 import EditBox from '../EditBox/EditBox.js';
 import './AppPlayList.css';
 
 export const AppPlayList = () => {
-  const { editBoxIsOpen } = useTrack();
+  const { editBoxIsOpen } = usePlaylist();
 
   if (editBoxIsOpen === true) {
     return (

--- a/src/components/EditBox/EditBox.js
+++ b/src/components/EditBox/EditBox.js
@@ -1,5 +1,6 @@
 import React, { useContext, useRef } from 'react';
 import usePlaylist from '../../hooks/usePlaylist';
+import useSpotify from '../../hooks/useSpotify';
 import { PositionContext } from '../../context/PositionContext';
 import EditBoxTracks from '../EditBoxTracks/EditBoxTracks';
 
@@ -11,8 +12,9 @@ const EditBox = () => {
   const { state } = useContext(PositionContext);
   const { playListPosition } = state;
   
-  const { editBoxIsOpen, editListPlayLists, editListTracks, 
-          openPlayLists, updatePlayList } = usePlaylist();
+  const { editBoxIsOpen, editListPlayLists, editListTracks, updatePlayList } = usePlaylist();
+
+  const { openPlayLists } = useSpotify();
     
 
   const handleEditListClick = (e) => {

--- a/src/components/EditBox/EditBox.js
+++ b/src/components/EditBox/EditBox.js
@@ -12,9 +12,8 @@ const EditBox = () => {
   const { state } = useContext(PositionContext);
   const { playListPosition } = state;
   
-  const { editBoxIsOpen, editListPlayLists, editListTracks, updatePlayList } = usePlaylist();
-
-  const { openPlayLists } = useSpotify();
+  const { editBoxIsOpen, editListPlayLists, editListTracks } = usePlaylist();
+  const { openPlayLists, updatePlayList } = useSpotify();
     
 
   const handleEditListClick = (e) => {

--- a/src/components/EditBox/EditBox.js
+++ b/src/components/EditBox/EditBox.js
@@ -1,5 +1,5 @@
 import React, { useContext, useRef } from 'react';
-import useTrack from '../../hooks/useTrack';
+import usePlaylist from '../../hooks/usePlaylist';
 import { PositionContext } from '../../context/PositionContext';
 import EditBoxTracks from '../EditBoxTracks/EditBoxTracks';
 
@@ -12,7 +12,7 @@ const EditBox = () => {
   const { playListPosition } = state;
   
   const { editBoxIsOpen, editListPlayLists, editListTracks, 
-          openPlayLists, updatePlayList } = useTrack();
+          openPlayLists, updatePlayList } = usePlaylist();
     
 
   const handleEditListClick = (e) => {

--- a/src/components/EditBoxTracks/EditBoxTracks.js
+++ b/src/components/EditBoxTracks/EditBoxTracks.js
@@ -12,15 +12,15 @@ const EditBoxTracks = (props) => {
     return (
       <div className="TrackList">
         {
-          editListTracks.map(track => {
+          editListTracks.map((track, index) => {
             return (
-              <div key={track.uri} className="Track">
+              <div key={`${track.uri}:${index}`} className="Track">
                 <div className="Track-information" id="track">
                   <h3>{track.name}</h3>
                   <p>{track.artistName} | {track.albumName}</p>
                 </div>
                 <button className="Track-action"
-                  onClick={() => removeTrack(track, true)}>-</button>
+                  onClick={() => removeTrack(index, true)}>-</button>
               </div>
             );
           })

--- a/src/components/EditBoxTracks/EditBoxTracks.js
+++ b/src/components/EditBoxTracks/EditBoxTracks.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import useTrack from '../../hooks/useTrack';
+import usePlaylist from '../../hooks/usePlaylist';
 // import usePagination from '../../hooks/usePagination';
 
 import './EditBoxTracks.css';
 
 const EditBoxTracks = (props) => {
-  const { removeTrack, editListTracks } = useTrack();
+  const { removeTrack, editListTracks } = usePlaylist();
   // const { pageOfItems } = usePagination();
 
   if (Array.isArray(editListTracks) && editListTracks.length > 0) {

--- a/src/components/EditList/EditList.js
+++ b/src/components/EditList/EditList.js
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react';
-import useTrack from '../../hooks/useTrack';
+import usePlaylist from '../../hooks/usePlaylist';
 import { PositionContext } from '../../context/PositionContext';
 
 import './EditList.css';
 
 export const EditList = (props) => {
   const { dispatch } = useContext(PositionContext);
-  const { editListPlayLists, getTracksFromPlayList } = useTrack();
+  const { editListPlayLists, getTracksFromPlayList } = usePlaylist();
 
   const handleClick = (e, playlistId, newplayListPosition) => {
     e.preventDefault();

--- a/src/components/EditList/EditList.js
+++ b/src/components/EditList/EditList.js
@@ -1,12 +1,14 @@
 import React, { useContext } from 'react';
 import usePlaylist from '../../hooks/usePlaylist';
+import useSpotify from '../../hooks/useSpotify';
 import { PositionContext } from '../../context/PositionContext';
 
 import './EditList.css';
 
 export const EditList = (props) => {
   const { dispatch } = useContext(PositionContext);
-  const { editListPlayLists, getTracksFromPlayList } = usePlaylist();
+  const { editListPlayLists } = usePlaylist();
+  const { getTracksFromPlayList } = useSpotify();
 
   const handleClick = (e, playlistId, newplayListPosition) => {
     e.preventDefault();

--- a/src/components/ListOfPlayLists/ListOfPlayLists.js
+++ b/src/components/ListOfPlayLists/ListOfPlayLists.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import usePlaylist from '../../hooks/usePlaylist';
+import useSpotify from '../../hooks/useSpotify';
 import { EditList } from '../EditList/EditList.js';
 
 import './ListOfPlayLists.css';
 
 export const ListOfPlayLists = (props) => {
-  const { editListIsOpen, editListPlayLists, openPlayLists } = usePlaylist();
+  const { editListIsOpen, editListPlayLists } = usePlaylist();
+  const { openPlayLists } = useSpotify();
 
   if (editListIsOpen === true && Array.isArray(editListPlayLists)) {
     return (

--- a/src/components/ListOfPlayLists/ListOfPlayLists.js
+++ b/src/components/ListOfPlayLists/ListOfPlayLists.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import useTrack from '../../hooks/useTrack';
+import usePlaylist from '../../hooks/usePlaylist';
 import { EditList } from '../EditList/EditList.js';
 
 import './ListOfPlayLists.css';
 
 export const ListOfPlayLists = (props) => {
-  const { editListIsOpen, editListPlayLists, openPlayLists } = useTrack();
+  const { editListIsOpen, editListPlayLists, openPlayLists } = usePlaylist();
 
   if (editListIsOpen === true && Array.isArray(editListPlayLists)) {
     return (

--- a/src/components/PlayList/PlayList.js
+++ b/src/components/PlayList/PlayList.js
@@ -9,8 +9,8 @@ export const PlayList = (props) => {
   const { state } = useContext(PlayListContext);
   const { playListTracks } = state; 
 
-  const { removeTrack, savePlayList } = usePlaylist();
-  const { openPlayLists } = useSpotify();
+  const { removeTrack } = usePlaylist();
+  const { openPlayLists, savePlayList } = useSpotify();
 
   const handleTitleChange = () => {
     let title = titleRef.current.value;

--- a/src/components/PlayList/PlayList.js
+++ b/src/components/PlayList/PlayList.js
@@ -1,6 +1,6 @@
 import React, { useContext, useRef } from 'react';
 import { PlayListContext } from '../../context/PlayListContext';
-import useTrack from '../../hooks/useTrack';
+import usePlaylist from '../../hooks/usePlaylist';
 import './PlayList.css';
 
 export const PlayList = (props) => {
@@ -8,7 +8,7 @@ export const PlayList = (props) => {
   const { state } = useContext(PlayListContext);
   const { playListTracks } = state; 
 
-  const { openPlayLists, removeTrack, savePlayList } = useTrack();
+  const { openPlayLists, removeTrack, savePlayList } = usePlaylist();
 
   const handleTitleChange = () => {
     let title = titleRef.current.value;

--- a/src/components/PlayList/PlayList.js
+++ b/src/components/PlayList/PlayList.js
@@ -1,6 +1,7 @@
 import React, { useContext, useRef } from 'react';
 import { PlayListContext } from '../../context/PlayListContext';
 import usePlaylist from '../../hooks/usePlaylist';
+import useSpotify from '../../hooks/useSpotify';
 import './PlayList.css';
 
 export const PlayList = (props) => {
@@ -8,7 +9,8 @@ export const PlayList = (props) => {
   const { state } = useContext(PlayListContext);
   const { playListTracks } = state; 
 
-  const { openPlayLists, removeTrack, savePlayList } = usePlaylist();
+  const { removeTrack, savePlayList } = usePlaylist();
+  const { openPlayLists } = useSpotify();
 
   const handleTitleChange = () => {
     let title = titleRef.current.value;

--- a/src/components/PlayList/PlayList.js
+++ b/src/components/PlayList/PlayList.js
@@ -32,14 +32,14 @@ export const PlayList = (props) => {
         <button className="Show-playlist-list" onClick={openPlayLists}>EDIT PLAYLISTS</button>
         <div className="TrackList">
         {
-          playListTracks.map(track => {
+          playListTracks.map((track, index) => {
             return (
-              <div key={track.uri} className="Track">
+              <div key={`${track.uri}:${index}`} className="Track">
                 <div className="Track-information" id="track">
                   <h3>{track.name}</h3>
                   <p>{track.artistName} | {track.albumName}</p>
                 </div>
-                <button className="Track-action" onClick={() => removeTrack(track)}>-</button>
+                <button className="Track-action" onClick={() => removeTrack(index)}>-</button>
               </div>
             );
           })

--- a/src/components/SearchResults/SearchResults.js
+++ b/src/components/SearchResults/SearchResults.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from 'react';
 import { SearchContext } from '../../context/SearchContext';
 import useSpotify from '../../hooks/useSpotify';
-import useTrack from '../../hooks/useTrack';
+import usePlaylist from '../../hooks/usePlaylist';
 import './SearchResults.css';
 
 
@@ -12,7 +12,7 @@ export const SearchResults = (props) => {
   const { state, dispatch } = useContext(SearchContext);
   const { artist, album, track, searchTerms, sortBy } = state;
   const { artistResult, albumResult, getAlbumsFromArtist, getTracksFromAlbum, trackResult } = useSpotify();
-  const { addTrack } = useTrack();
+  const { addTrack } = usePlaylist();
 
   const renderSortByOptions = () => {
     return sortByOptions.map(sortValue => {

--- a/src/hooks/usePlaylist.js
+++ b/src/hooks/usePlaylist.js
@@ -11,21 +11,20 @@ const usePlaylist = () => {
     return dispatch({ type: 'UPDATE_PLAY_LIST_TRACKS', tracks: trackInfo });
   }
 
-  function removeTrack(uri, editList=false) {
+  function removeTrack(trackIndex, editListOpen=false) {
     let trackArray;
 
-    if (editList === true) trackArray = [...editListTracks];
+    if (editListOpen === true) trackArray = [...editListTracks];
     else trackArray = [...playListTracks];
 
-    function remove(array, element) {
-      const index = array.indexOf(element);
-      array.splice(index, 1);
+    function remove(playList, index) {
+      playList.splice(index, 1);
 
-      if (editList === true) dispatch({ type: 'REMOVE_EDIT_LIST_TRACKS', tracks: array });
-      else dispatch({ type: 'REMOVE_PLAY_LIST_TRACKS', tracks: array });
+      if (editListOpen === true) dispatch({ type: 'REMOVE_EDIT_LIST_TRACKS', tracks: playList });
+      else dispatch({ type: 'REMOVE_PLAY_LIST_TRACKS', tracks: playList });
     }
 
-    remove(trackArray, uri);
+    remove(trackArray, trackIndex);
   }
 
   function updateEditPlaylistTracks(tracks) {

--- a/src/hooks/usePlaylist.js
+++ b/src/hooks/usePlaylist.js
@@ -32,51 +32,24 @@ const usePlaylist = () => {
     remove(trackArray, uri);
   }
 
-  function updateEditPlaylist(tracks) {
+  function updateEditPlaylistTracks(tracks) {
     dispatch({ type: 'SET_EDIT_LIST_TRACKS', tracks: tracks });
     dispatch({ type: 'UPDATE_SHOW_EDIT_LIST', show: false });
     dispatch({ type: 'UPDATE_SHOW_EDIT_BOX', show: true });
   }
 
-  function openPlayLists(e) {
-    e.preventDefault();
-
+  function closeEditPlayLists() {
     if (editListIsOpen === true) {
-      return dispatch({ type: 'UPDATE_SHOW_EDIT_LIST', show: false });
+      dispatch({ type: 'UPDATE_SHOW_EDIT_LIST', show: false });
+      return true;
     }
 
-    // Abort username request if it is taking too long
-    const controller = new AbortController();
-    const signal = controller.signal;
-    setTimeout(() => controller.abort(), 6000);
+    return false;
+  }
 
-    fetch("https://api.spotify.com/v1/me/playlists", { headers: {
-      'Authorization': 'Bearer ' + spotifyAccessToken
-      },
-      signal
-    })
-    .then(response => { return response.json() })
-    .then(jsonResponse => {
-      if (jsonResponse.items.length) {
-        return jsonResponse.items.map((items, num) => {
-          return {
-            name: items.name,
-            count: items.tracks.total,
-            id: items.id,
-            user: spotifyUsername,
-            position: num
-          }
-        });
-      } else {
-        return;
-      }
-
-    })
-    .then(playlists => {
-      dispatch({ type: 'UPDATE_EDIT_PLAY_LISTS', lists: playlists });
-      dispatch({ type: 'UPDATE_SHOW_EDIT_LIST', show: true });
-    })
-    .catch(err => { alert(`Getting playlists error: ${err.message}`); });
+  function populateUserPlayLists(playlists) {
+    dispatch({ type: 'UPDATE_EDIT_PLAY_LISTS', lists: playlists });
+    dispatch({ type: 'UPDATE_SHOW_EDIT_LIST', show: true });
   }
 
   function savePlayList(title) {
@@ -222,16 +195,17 @@ const usePlaylist = () => {
 
   return {
     addTrack,
+    closeEditPlayLists,
     editBoxIsOpen,
     editListIsOpen,
     editListPlayLists, 
     editListTracks,
-    updateEditPlaylist,
-    openPlayLists,
     playListTracks,
     playListPosition,
     removeTrack,
     savePlayList,
+    populateUserPlayLists,
+    updateEditPlaylistTracks,
     updatePlayList,
   }
 };

--- a/src/hooks/usePlaylist.js
+++ b/src/hooks/usePlaylist.js
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { AuthContext } from '../context/AuthContext';
 import { PlayListContext } from "../context/PlayListContext";
 
-const useTrack = () => {
+const usePlaylist = () => {
   const { state, dispatch } = useContext(PlayListContext);
   const { editBoxIsOpen, editListIsOpen, editListTracks, editListPlayLists, 
           playListTracks, playListPosition } = state;
@@ -297,4 +297,4 @@ const useTrack = () => {
   }
 };
 
-export default useTrack;
+export default usePlaylist;

--- a/src/hooks/usePlaylist.js
+++ b/src/hooks/usePlaylist.js
@@ -52,67 +52,7 @@ const usePlaylist = () => {
     dispatch({ type: 'UPDATE_SHOW_EDIT_LIST', show: true });
   }
 
-  function savePlayList(title) {
-    let tracks = [];
-    playListTracks.map(track => { return tracks = [...tracks, track.uri] });
-
-    // Abort username request if it is taking too long
-    const controller = new AbortController();
-    const signal = controller.signal;
-    setTimeout(() => controller.abort(), 6000);
-
-    const titleRequest = new Request('https://api.spotify.com/v1/users/' + spotifyUsername +
-    '/playlists', {
-    	method: 'POST',
-    	headers: {
-    		'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + spotifyAccessToken
-      },
-      body: JSON.stringify({ name: title }),
-      signal
-    });
-
-    function addPlayList() { 
-      return fetch(titleRequest)
-      .then(response => {
-        return response.json();
-      })
-      .then(jsonResponse => {
-        console.log(jsonResponse);
-        return jsonResponse.id;
-      })
-      .catch(err => { alert(`Adding playlist error: ${err.message}`) });
-    }
-
-    function addTracks(trackRequest)  {
-      return fetch(trackRequest)
-      .then(response => {
-        return response.json();
-      })
-      .then(jsonResponse => {
-        return jsonResponse;
-      })
-      .catch(err => { alert(`Adding tracks to playlist error: ${err.message}`); });
-    }
-
-    
-    addPlayList()
-    .then(playListID => {
-      let trackRequest = new Request('https://api.spotify.com/v1/users/' +
-      spotifyUsername + '/playlists/' + playListID + '/tracks', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer ' + spotifyAccessToken
-        },
-        body: JSON.stringify({ uris: tracks }),
-        signal
-      });
-
-      return trackRequest;
-    })
-    .then(trackRequest => { return addTracks(trackRequest) });
-    
+  function clearPlayListTracks() {
     dispatch({ type: 'CLEAR_PLAY_LIST_TRACKS', tracks: [] });
   }
 
@@ -195,6 +135,7 @@ const usePlaylist = () => {
 
   return {
     addTrack,
+    clearPlayListTracks,
     closeEditPlayLists,
     editBoxIsOpen,
     editListIsOpen,
@@ -203,7 +144,6 @@ const usePlaylist = () => {
     playListTracks,
     playListPosition,
     removeTrack,
-    savePlayList,
     populateUserPlayLists,
     updateEditPlaylistTracks,
     updatePlayList,

--- a/src/hooks/usePlaylist.js
+++ b/src/hooks/usePlaylist.js
@@ -32,71 +32,10 @@ const usePlaylist = () => {
     remove(trackArray, uri);
   }
 
-  function getTracksFromPlayList(playlist_id) {
-    let trackCount = 0; // number of songs in increments of 100
-    let iterationCount = 1; // tracks number of times API call is made
-    let offset = 0; // offsets track number for API call
-    let playlistTracks = []; // used to store tracks gathered from each API call
-    // Abort username request if it is taking too long
-    const controller = new AbortController();
-    const signal = controller.signal;
-    setTimeout(() => controller.abort(), 6000);
-
-    function fetchTracks() {
-      return fetch(`https://api.spotify.com/v1/users/${spotifyUsername}/playlists/${playlist_id}/tracks?offset=${offset}&limit=100`,
-        { headers: {
-          'Authorization': 'Bearer ' + spotifyAccessToken
-        },
-        signal
-      })
-      .then(response => { return response.json() })
-      .then(jsonResponse => {
-        if (jsonResponse.items && jsonResponse.items.length) { 
-          return jsonResponse.items.map((item, num) => {
-            if (num === 99) {
-              trackCount +=100;
-            }
-            return playlistTracks = [...playlistTracks,
-              {
-                track: item.track.name,
-                artist: item.track.artists[0].name,
-                album: item.track.album.name,
-                uri: item.track.uri
-              }
-            ];
-          });
-        } else return playlistTracks;
-      })
-      .then(jsonResponse => {
-        if (trackCount / iterationCount === 100) {
-          iterationCount += 1;
-          offset += 100;
-          return fetchTracks();
-        } else return playlistTracks;
-      })
-    }
-
-    fetchTracks()
-    .then(data => {
-      if (data) {
-        return data.map(track => {
-          return {
-            artistName: track.artist,
-            albumName: track.album,
-            name: track.track,
-            uri: track.uri
-          }
-        });
-      } else return [];
-    })
-    .then(tracks => {
-      if (tracks) {
-        dispatch({ type: 'SET_EDIT_LIST_TRACKS', tracks: tracks });
-        dispatch({ type: 'UPDATE_SHOW_EDIT_LIST', show: false });
-        dispatch({ type: 'UPDATE_SHOW_EDIT_BOX', show: true });
-      }
-    })
-    .catch(err => { alert(`Getting tracks from playlist error: ${err.message}`); });
+  function updateEditPlaylist(tracks) {
+    dispatch({ type: 'SET_EDIT_LIST_TRACKS', tracks: tracks });
+    dispatch({ type: 'UPDATE_SHOW_EDIT_LIST', show: false });
+    dispatch({ type: 'UPDATE_SHOW_EDIT_BOX', show: true });
   }
 
   function openPlayLists(e) {
@@ -287,7 +226,7 @@ const usePlaylist = () => {
     editListIsOpen,
     editListPlayLists, 
     editListTracks,
-    getTracksFromPlayList,
+    updateEditPlaylist,
     openPlayLists,
     playListTracks,
     playListPosition,

--- a/src/hooks/useSpotify.js
+++ b/src/hooks/useSpotify.js
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import 'whatwg-fetch';
 import { AuthContext } from '../context/AuthContext';
 import { SearchContext } from '../context/SearchContext';
-import useTrack from './useTrack';
+import usePlaylist from './usePlaylist';
 
 
 const useSpotify = () => {
@@ -18,7 +18,7 @@ const useSpotify = () => {
   const { state: authState, dispatch: authDispatch } = useContext(AuthContext);
   const { spotifyAccessToken, spotifyClientID } = authState;
 
-  const { addTrack } = useTrack();
+  const { addTrack } = usePlaylist();
 
   useEffect(() => {
     function searchArtist(terms) {


### PR DESCRIPTION
-Rename useTracks to usePlaylist
-Move all Spotify API calls from usePlaylist to useSpotify
-Refactory removeTrack() method in usePlaylist to remove tracks by index instead of their URI (so that you can have the same track in the same playlist and remove it without any bugs)